### PR TITLE
Avoid estimate_search_count in global context and fix False context

### DIFF
--- a/bin/widget/screen/screen.py
+++ b/bin/widget/screen/screen.py
@@ -208,7 +208,8 @@ class Screen(signal_event.signal_event):
         sb.set_label(msg)
 
     def search_filter(self, exact_count=True, *args):
-        self.context.update({'estimate_search_count': not exact_count})
+        ctx = self.context.copy()
+        ctx.update({'estimate_search_count': not exact_count})
         v = self.filter_widget.value
         filter_keys = [ key for key, _, _ in v]
 
@@ -231,12 +232,12 @@ class Screen(signal_event.signal_event):
         offset=self.search_offset_add()
 
         self.latest_search = v
-        ids = rpc.session.rpc_exec_auth('/object', 'execute', self.name, 'search', v, offset, limit, 0, self.context)
+        ids = rpc.session.rpc_exec_auth('/object', 'execute', self.name, 'search', v, offset, limit, 0, ctx)
         if len(ids) < limit:
             self.search_count = len(ids)
             exact_count = True
         else:
-            self.search_count = rpc.session.rpc_exec_auth_try('/object', 'execute', self.name, 'search_count', v, self.context)
+            self.search_count = rpc.session.rpc_exec_auth_try('/object', 'execute', self.name, 'search_count', v, ctx)
             if not exact_count:
                 estimate_min_value = options.options['client.estimate_min_value']
                 exact_count = self.search_count < estimate_min_value

--- a/bin/widget/view/form.py
+++ b/bin/widget/view/form.py
@@ -182,7 +182,7 @@ class ViewForm(parser_view):
                                 common.message(_('You must select a record to use the relate button !'))
                                 return False
                             act['domain'] = self.screen.current_model.expr_eval(act['domain'], check_load=False)
-                            act['context'] = str(self.screen.current_model.expr_eval(act['context'], check_load=False))
+                            act['context'] = str(self.screen.current_model.expr_eval(act['context'] or {}, check_load=False))
                         obj = service.LocalService('action.main')
                         value = obj._exec_action(act, data, context)
                         if type in ('print', 'action'):


### PR DESCRIPTION
Two bugs were found:
    `estimate_search_count` should appear in context only for client searches, not inside other functions.
    When context = False in `related` actions there was an exception and the menu didn't open.